### PR TITLE
If the config file is NOT found, the error is never shown unless verbose...

### DIFF
--- a/src/ca/mcgill/mcb/pcingola/bigDataScript/Config.java
+++ b/src/ca/mcgill/mcb/pcingola/bigDataScript/Config.java
@@ -349,7 +349,9 @@ public class Config {
 		properties = new Properties();
 
 		if (!Gpr.exists(configFileName)) {
-			if (verbose) Timer.showStdErr("Config file '" + configFileName + "' not found");
+			// If the config file is NOT found, the error is never shown unless verbose is set.
+			// The error should always be shown.
+			//if (verbose) Timer.showStdErr("Config file '" + configFileName + "' not found");
 			return;
 		}
 


### PR DESCRIPTION
... is set.  The error should always be shown.  The patch is incorrect.  the line should read:

Timer.showStdErr("Config file '" + configFileName + "' not found");

not 
if (verbose) Timer.showStdErr("Config file '" + configFileName + "' not found");

I cannot figure out how to make the change in Github