### PR TITLE
fixed taskId.isDone() issue

### DIFF
--- a/src/org/bds/lang/nativeMethods/string/MethodNative_string_exitCode.java
+++ b/src/org/bds/lang/nativeMethods/string/MethodNative_string_exitCode.java
@@ -4,6 +4,7 @@ import org.bds.lang.Parameters;
 import org.bds.lang.Type;
 import org.bds.lang.nativeMethods.MethodNative;
 import org.bds.run.BdsThread;
+import org.bds.run.BdsThreads;
 import org.bds.task.Task;
 
 public class MethodNative_string_exitCode extends MethodNative {
@@ -26,7 +27,7 @@ public class MethodNative_string_exitCode extends MethodNative {
 	@Override
 	protected Object runMethodNative(BdsThread bdsThread, Object objThis) {
 		String taskId = objThis.toString();
-		Task task = bdsThread.getTask(taskId);
+		Task task = BdsThreads.getTask(taskId);
 		if (task == null) return 0L;
 		return (long) task.getExitValue();
 	}

--- a/src/org/bds/lang/nativeMethods/string/MethodNative_string_isDone.java
+++ b/src/org/bds/lang/nativeMethods/string/MethodNative_string_isDone.java
@@ -4,6 +4,7 @@ import org.bds.lang.Parameters;
 import org.bds.lang.Type;
 import org.bds.lang.nativeMethods.MethodNative;
 import org.bds.run.BdsThread;
+import org.bds.run.BdsThreads;
 import org.bds.task.Task;
 
 public class MethodNative_string_isDone extends MethodNative {
@@ -26,7 +27,7 @@ public class MethodNative_string_isDone extends MethodNative {
 	@Override
 	protected Object runMethodNative(BdsThread bdsThread, Object objThis) {
 		String taskId = objThis.toString();
-		Task task = bdsThread.getTask(taskId);
+		Task task = BdsThreads.getTask(taskId);
 		if (task == null) return false;
 		return task.isDone();
 	}

--- a/src/org/bds/lang/nativeMethods/string/MethodNative_string_isDoneOk.java
+++ b/src/org/bds/lang/nativeMethods/string/MethodNative_string_isDoneOk.java
@@ -9,6 +9,7 @@ import org.bds.lang.Type;
 import org.bds.lang.TypeList;
 import org.bds.lang.nativeMethods.MethodNative;
 import org.bds.run.BdsThread;
+import org.bds.run.BdsThreads;
 import org.bds.task.Task;
 import org.bds.util.Gpr;
 
@@ -31,6 +32,9 @@ public class MethodNative_string_isDoneOk extends MethodNative {
 
 	@Override
 	protected Object runMethodNative(BdsThread csThread, Object objThis) {
-		String taskId = objThis.toString(); Task task = csThread.getTask(taskId); if (task == null) return false; return task.isDoneOk();
+		String taskId = objThis.toString();
+		Task task = BdsThreads.getTask(taskId);
+		if (task == null) return false;
+		return task.isDoneOk();
 	}
 }

--- a/src/org/bds/lang/nativeMethods/string/MethodNative_string_stderr.java
+++ b/src/org/bds/lang/nativeMethods/string/MethodNative_string_stderr.java
@@ -4,6 +4,7 @@ import org.bds.lang.Parameters;
 import org.bds.lang.Type;
 import org.bds.lang.nativeMethods.MethodNative;
 import org.bds.run.BdsThread;
+import org.bds.run.BdsThreads;
 import org.bds.task.Task;
 import org.bds.util.Gpr;
 
@@ -27,7 +28,7 @@ public class MethodNative_string_stderr extends MethodNative {
 	@Override
 	protected Object runMethodNative(BdsThread bdsThread, Object objThis) {
 		String taskId = objThis.toString();
-		Task task = bdsThread.getTask(taskId);
+		Task task = BdsThreads.getTask(taskId);
 		if (task == null) return "";
 		return Gpr.readFile(task.getStderrFile(), false);
 	}

--- a/src/org/bds/lang/nativeMethods/string/MethodNative_string_stdout.java
+++ b/src/org/bds/lang/nativeMethods/string/MethodNative_string_stdout.java
@@ -9,6 +9,7 @@ import org.bds.lang.Type;
 import org.bds.lang.TypeList;
 import org.bds.lang.nativeMethods.MethodNative;
 import org.bds.run.BdsThread;
+import org.bds.run.BdsThreads;
 import org.bds.task.Task;
 import org.bds.util.Gpr;
 
@@ -31,6 +32,9 @@ public class MethodNative_string_stdout extends MethodNative {
 
 	@Override
 	protected Object runMethodNative(BdsThread csThread, Object objThis) {
-		String taskId = objThis.toString(); Task task = csThread.getTask(taskId); if (task == null) return ""; return Gpr.readFile(task.getStdoutFile(), false);
+		String taskId = objThis.toString();
+		Task task = BdsThreads.getTask(taskId);
+		if (task == null) return "";
+		return Gpr.readFile(task.getStdoutFile(), false);
 	}
 }

--- a/src/org/bds/run/BdsThreads.java
+++ b/src/org/bds/run/BdsThreads.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.bds.data.Data;
+import org.bds.task.Task;
 
 /**
  * All BdsThreads are tracked here
@@ -72,6 +73,18 @@ public class BdsThreads {
 			bdsThreadByThreadId.remove(id);
 			bdsThreadDone.add(bdsThread);
 		} else throw new RuntimeException("Cannot remove thread '" + bdsThread.getBdsThreadId() + "'");
+	}
+
+	public static Task getTask(String taskId) {
+		for (BdsThread bdsThread : getInstance().bdsThreadByThreadId.values()) {
+			Task task = bdsThread.getTask(taskId);
+			if (task != null) return task;
+		}
+		for (BdsThread bdsThread : getInstance().bdsThreadDone) {
+			Task task = bdsThread.getTask(taskId);
+			if (task != null) return task;
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
For member functions; isDone(), isDoneOk(), exitCode(), stderr() and stdout(), use the singleton class `BdsThreads` to search for tasks so that tasks in other threads can also be found.