### PR TITLE
allow bds to build and install without a user home directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 		<copy file="src/org/bds/SummaryTemplate.html" tofile="bin/org/bds/SummaryTemplate.html"/>
 		<copy file="src/org/bds/SummaryTemplate.yaml" tofile="bin/org/bds/SummaryTemplate.yaml"/>
 		<copy file="./src/org/bds/DagTaskTemplate.js" tofile="bin/org/bds/DagTaskTemplate.js"/>
-        <jar destfile="${user.home}/.bds/bds.jar" filesetmanifest="mergewithoutmain">
+        <jar destfile="build/bds.jar" filesetmanifest="mergewithoutmain">
             <manifest>
                 <attribute name="Main-Class" value="org.bigDataScript.Bds"/>
                 <attribute name="Class-Path" value="."/>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -ex
-
-BDS_HOME="$HOME/.bds"
+if [ -z ${BDS_HOME} ]; then
+    BDS_HOME="$HOME/.bds"
+fi
+ORIGDIR=${PWD}
 
 echo "Changing dir" `dirname $0`
 
@@ -29,13 +31,13 @@ go build
 go fmt
 
 # Build binay (go executable + JAR file)
-cat bds "$BDS_HOME/bds.jar" > bds.bin
+cat bds "${ORIGDIR}/build/bds.jar" > bds.bin
 mv bds.bin bds
 chmod a+x bds
 mv bds "$BDS_HOME"
 
 # Remove JAR file
-rm "$BDS_HOME/bds.jar"
+rm "${ORIGDIR}/build/bds.jar"
 
 # Binary installed
 echo "Binary created: $BDS_HOME/bds"


### PR DESCRIPTION
Hi,
This commit changes build behaviour a little bit:
The bds.jar will build under the source directory.
If BDS_HOME environment variable is undefined, install behaviour will be as before
If BDS_HOME is defined, install will proceeed to that location

This possibly addresses issue #123 (building packages on archlinux)
I made this change so I can build singularity containers

Cheers,
--
Chris.