### PR TITLE
Added static BDS_HOME variable and getBdsConfig method to Gpr class

### DIFF
--- a/src/org/bds/Config.java
+++ b/src/org/bds/Config.java
@@ -25,8 +25,10 @@ import org.bds.util.Timer;
  */
 public class Config {
 
-	public static final String DEFAULT_CONFIG_DIR = Gpr.HOME + "/.bds";
-	public static final String DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR + "/bds.config";
+	// We want to put bds.config together with bds executable
+	// by default BDS_HOME == HOME
+	public static final String DEFAULT_CONFIG_DIR = Gpr.BDS_HOME;
+	public static final String DEFAULT_CONFIG_FILE = Gpr.getBdsConfig();
 	public static final String DEFAULT_INCLUDE_DIR = DEFAULT_CONFIG_DIR + "/include";
 
 	public static final String BDS_INCLUDE_PATH = "BDS_PATH"; // BDS include path (colon separated list of directories to look for include files)

--- a/src/org/bds/util/Gpr.java
+++ b/src/org/bds/util/Gpr.java
@@ -107,6 +107,35 @@ public class Gpr {
 
 	// User's home directory
 	public static final String HOME = System.getProperty("user.home");
+	// bds installation directory
+	public static final String BDS_HOME = System.getenv("BDS_HOME");
+
+	public static final String getBdsConfig() {
+
+		String currentBdsConfig = System.getProperty("user.dir");
+		currentBdsConfig += "/bds.config";
+		File localConfig = new File(currentBdsConfig);
+
+		String homeBdsConfig = HOME;
+		homeBdsConfig += "/.bds/bds.config";
+		File userLocalConfig = new File(homeBdsConfig);
+
+		if(localConfig.exists()) {
+			return localConfig.toString();
+		} else if(userLocalConfig.exists()) {
+			return userLocalConfig.toString();
+		} else {
+			String bdsConfig = new File(Gpr.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getParent();
+			bdsConfig += "/bds.config";
+			File globalConfig = new File(bdsConfig);
+
+			if(!globalConfig.exists()) {
+				throw new java.lang.RuntimeException("This sohuldn't happen.");
+			}
+
+			return globalConfig.toString();
+		}
+	}
 
 	/**
 	 * Return file's name (without the path)


### PR DESCRIPTION
@pcingola I've removed previous PR (same commit) cause I realised that  "config" as a name of the branch was bad choice as it was conflicting with local directory also called config. I was having some issues to checkout config branch :)

I'm trying to address an issue that `bds` executable has hard coded path of the `bds.config` which is [this](https://github.com/pcingola/BigDataScript/blob/98a7076a137fdc20c0fe8f19073b4f16eeed8496/src/org/bds/Config.java#L28) And seem to always struggle to locate `bds.config` and we do this kind of "hack" `echo $(which bds)/bds.config` which is a bit annoying. 

A colleague have packaged BDS as conda package and once again we need "smarter" `bds.config` locator, which I attempted to make.  

> variable for finding default config path, otherwise bds gets installed
into BDS_HOME but still looks for bds.config at HOME/.bds/
Also add new method getBdsConfig to Gpr class, that search "hierarchy"
for config file. Precendent in this order: local directory, $HOME/bds
directory, global directory - next to executable file (install directory)

TODO: not sure if I need to check validity of `bds.config` or it gets
checked by Config class (I think it does). 

**TODO: also not sure if I can pass some parameters from local config and
the rest of stuff comes from global config. I don't this is the case**
