### PR TITLE
Fix CDN links for Bootstrap CSS and Cytoscape.

### DIFF
--- a/src/org/bds/SummaryTemplate.html
+++ b/src/org/bds/SummaryTemplate.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-    <link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://unpkg.com/bootstrap@4.1.1/dist/css/bootstrap.min.css" rel="stylesheet">
 	<style type="text/css">
 		pre {
 			width:1200px;
@@ -10,7 +10,7 @@
 		}
 	</style>    
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
-	<script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min.js"></script>
+	<script src="https://unpkg.com/cytoscape@3.2.14/dist/cytoscape.min.js"></script>
 	<script src="{{dagJsFile}}"></script>
 </head>
 <body>


### PR DESCRIPTION
Locked versions so that breaking changes in upstream libraries don't break old reports.